### PR TITLE
Add Guava to dependencies

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile 'com.jakewharton:butterknife:7.0.0'
 
     compile 'com.google.dagger:dagger:2.0.2'
+    compile 'com.google.guava:guava:19.0'
 
     compile 'com.squareup.okhttp:okhttp:2.6.0'
     compile 'io.reactivex:rxandroid:1.0.1'


### PR DESCRIPTION
MainActivity is dependent from `com.google.common.base.Preconditions`, but Guava is absent in dependencies list, therefore the build was broken.
Now the project can be built successfully.
